### PR TITLE
added bayesian calculation of SMAB to nisb_bayes.

### DIFF
--- a/nisb_example.R
+++ b/nisb_example.R
@@ -33,16 +33,15 @@ admin_statistics_selected = list(mean_YZ_selected = colMeans(data_selected),
 # Set parameters for the nisb_bayes() and nisb() functions.
 random_seed = 1;
 ndraws = 1e4; # number of draws for Bayesian approach
-phi_character = "rep(c(0,0.5,1.0),length=ndraws)";
 return_plot = T;
 conf_level = 0.95;
-smub_intervals_at = c(0, 0.5, 1); # desired values of phi for generating predictions of SMUB
+intervals_at = c(0, 0.5, 1); # desired values of phi for generating predictions of SMUB
 
 # Apply fully Bayesian approach to NSFG data.
 fit1 = nisb_bayes(admin_statistics_selected, admin_statistics_no_selected, 
                   ndraws = ndraws,
                   phi_character = "runif(ndraws)",
-                  smub_intervals_at = smub_intervals_at, 
+                  intervals_at = intervals_at, 
                   conf_level = conf_level, 
                   random_seed = random_seed,
                   return_plot = return_plot);
@@ -51,21 +50,29 @@ fit1 = nisb_bayes(admin_statistics_selected, admin_statistics_no_selected,
 fit2 = nisb_bayes(admin_statistics_selected, admin_statistics_no_selected, 
                   ndraws = ndraws,
                   phi_character = "rep(c(0,0.5,1.0),length=ndraws)",
-                  smub_intervals_at = smub_intervals_at, 
+                  intervals_at = intervals_at, 
                   conf_level = conf_level, 
                   random_seed = random_seed,
                   return_plot = return_plot);
 
-# Compute 95% credible interval for SMUB, given uniform prior.
+# Compute 95% credible interval for SMUB & SMAB, given uniform prior.
 fit1$smub_summaries_marginal;
+fit1$smab_summaries_marginal;
 
 # Display predicted values of SMUB for specified values of phi, including 95% prediction intervals
 fit1$smub_summaries_conditional;
 #Nearly equal to the observed quantiles of SMUB when fixing phi at 0, 0.5, or 1 (as we would hope and expect)
 fit2$smub_summaries_conditional
 
+# Same for SMAB 
+fit1$smab_summaries_conditional;
+fit2$smab_summaries_conditional;
+
+
 # Generate SMUB(0), SMUB(0.5), and SMUB(1) using respondent data only. In this case, X is not directly observed
 # but is instead constructed from an initial regression of Y on Z, where Z is a multivariate administrative proxy. 
 # NOTE: foo$mean_X_pop can be replaced with the known mean for X from the target population.
 fit3 = nisb(mean_X_pop = fit1$mean_X_pop, admin_statistics_selected = admin_statistics_selected);
 fit3$smub_point_est;
+fit3$smab_point_est;
+


### PR DESCRIPTION
Rearranged some code in nisb_bayes.
Changed the way that the error variance is modeled after realizing that it wasn't flexible enough to handle the smab error structure. Previously it was s^2*(1 + |phi|^delta)^2, now it is s^2*(lambda + |phi|^delta)^2, where lambda is additionally estimated.
Updated the nisb_example to make sure that it was still telling the truth and doing correct things.