### PR TITLE
Edits from 9/25 phone call (revised)

### DIFF
--- a/enet.R
+++ b/enet.R
@@ -1,4 +1,10 @@
-donet <- function(dat, outcome_col, family, alpha_seq = 1, n_cv_rep = 10, n_folds = 5, interactions = NULL){
+donet <- function(dat, 
+                  outcome_col, 
+                  family, 
+                  alpha_seq = 1, 
+                  n_cv_rep = 10, 
+                  n_folds = 5, 
+                  interactions = NULL){
   
   if(family == "gaussian" || (family %in% c("multinomial","binomial") && class(dat[,outcome_col]) == "factor")) {
     y_train = dat[,outcome_col];
@@ -79,7 +85,7 @@ donet <- function(dat, outcome_col, family, alpha_seq = 1, n_cv_rep = 10, n_fold
   
   coefs = std_coefs = coef(curr_fit)[,which_best_lambda]; 
   coefs[main_effect_names] = coefs[main_effect_names] / scale_x_train;
-  #coefs[1] = coefs[1]  - sum(center_x_train  * coefs[main_effect_names]) + sum(center_x_train[interactions_as.dummy[,1]] * center_x_train[interactions_as.dummy[,2]] * coefs[interaction_names]);
+  coefs[1] = coefs[1]  - sum(center_x_train  * coefs[main_effect_names]) + sum(center_x_train[interactions_as.dummy[,1]] * center_x_train[interactions_as.dummy[,2]] * coefs[interaction_names]);
   if(length(interactions)) {
     coefs[interaction_names] = coefs[interaction_names] / (scale_x_train[interactions_as.dummy[,1]]*scale_x_train[interactions_as.dummy[,2]]);
     for(k in 1:nrow(interactions_as.dummy)) {

--- a/nisb_example.R
+++ b/nisb_example.R
@@ -36,24 +36,29 @@ ndraws = 1e4; # number of draws for Bayesian approach
 return_plot = T;
 conf_level = 0.95;
 intervals_at = c(0, 0.5, 1); # desired values of phi for generating predictions of SMUB
+poly_degree = 6; # degree of polynomial function of phi to fit to SMUB/SMAB plot. 
 
 # Apply fully Bayesian approach to NSFG data.
-fit1 = nisb_bayes(admin_statistics_selected, admin_statistics_no_selected, 
+fit1 = nisb_bayes(admin_statistics_selected = admin_statistics_selected, 
+                  admin_statistics_no_selected = admin_statistics_no_selected, 
                   ndraws = ndraws,
                   phi_character = "runif(ndraws)",
                   intervals_at = intervals_at, 
                   conf_level = conf_level, 
                   random_seed = random_seed,
-                  return_plot = return_plot);
+                  return_plot = return_plot, 
+                  poly_degree = poly_degree);
 
 # Alternative prior specification for Bayesian approach.
-fit2 = nisb_bayes(admin_statistics_selected, admin_statistics_no_selected, 
+fit2 = nisb_bayes(admin_statistics_selected = admin_statistics_selected, 
+                  admin_statistics_no_selected = admin_statistics_no_selected, 
                   ndraws = ndraws,
                   phi_character = "rep(c(0,0.5,1.0),length=ndraws)",
                   intervals_at = intervals_at, 
                   conf_level = conf_level, 
                   random_seed = random_seed,
-                  return_plot = return_plot);
+                  return_plot = return_plot, 
+                  poly_degree = poly_degree);
 
 # Compute 95% credible interval for SMUB & SMAB, given uniform prior.
 fit1$smub_summaries_marginal;

--- a/nisb_functions.R
+++ b/nisb_functions.R
@@ -4,7 +4,7 @@
 #
 # Authors: Brady T. West, Phil Boonstra (bwest@umich.edu, philb@umich.edu)
 #
-# Date: 9/12/2018, 10:30pm EST
+# Date: 9/25/2018, 3:00pm EST
 #
 # Function inputs:
 #
@@ -28,6 +28,11 @@
 #
 ### return_plot: (logical or character ['SMAB','SMUB']) should a SMUB plot be returned? If T or "SMUB", a plot of SMUB against phi is returned. If "SMAB", a plot of SMAB against phi is returned. Otherwise no plot is returned. 
 #
+### poly_degree: (integer) degree of polynomial function of phi to fit to SMUB/SMAB plot. If the correlation between x and y in the 
+#sampled units is close to zero and phi is close to 1, a degree of 10 or greater may be required to properly capture the relationship.
+#
+### sig_digits_return: (integer) number of significant digits to return in summaries. This does not affect the values in 'all_draws'
+#
 ### Value
 #Returns a list with the following named components: 'admin_statistics_selected', 'admin_statistics_no_selected', and 'random_seed' are as provided to the function;
 #'all_draws' is a matrix with columns for Bayesian draws of phi, smub, population_mean_Y, var_X_selected, var_Y_selected, and cor_XY_selected; 'smub_summaries_marginal'
@@ -42,7 +47,9 @@ nisb_bayes <- function(admin_statistics_selected,
                        intervals_at = c(0, 0.5, 1), 
                        conf_level = 0.95,
                        random_seed = sample(.Machine$integer.max,1), 
-                       return_plot = "SMUB")
+                       return_plot = "SMUB", 
+                       poly_degree = 6,
+                       sig_digits_return = 5)
 {
   require(mnormt);require(MCMCpack);require(ggplot2);require(nlme);require(magrittr);
   set.seed(random_seed);
@@ -105,8 +112,22 @@ nisb_bayes <- function(admin_statistics_selected,
   }
   cor_XY_selected_draws = var_XY_selected_draws_flattened[,2]/sqrt(var_XY_selected_draws_flattened[,1] * var_XY_selected_draws_flattened[,3])
   
+  #Resample all draws for which the implied correlation was negative
+  while(length(which_negative_cor_XY_selected_draws <- which(cor_XY_selected_draws < 0))) {
+    for (d in which_negative_cor_XY_selected_draws) {
+      var_XY_selected_observed[1,1] = var_X_selected_draws[d];
+      var_XY_selected_observed[1,2] =
+        var_XY_selected_observed[2,1] = beta_YZ.Z_selected_draws[d,-1]%*%var_YZ_selected[1,-1];
+      var_XY_selected_draw = riwish(n1 + 1, n1 * var_XY_selected_observed);
+      mean_XY_selected_draws[d,] = mean_XY_selected_draws[d,] +  bivariate_std_norm[d,]%*%chol(var_XY_selected_draw / n1);
+      var_XY_selected_draws_flattened[d,] = var_XY_selected_draw[c(1,2,4)];
+      cor_XY_selected_draws[d] = var_XY_selected_draws_flattened[d,2]/sqrt(var_XY_selected_draws_flattened[d,1] * var_XY_selected_draws_flattened[d,3])
+    }
+  }
+  
   #Draw phi using provided string
   phi_draws = eval(parse(text=phi_character));
+  phi_draws = pmax(.Machine$double.eps, pmin(1 - .Machine$double.eps, phi_draws));
   
   #Joint draws from distribution corresponding to non-selected population
   #Note: This next line makes a slight abuse of notation by overriding an existing variable with a new value. This is intentional
@@ -141,11 +162,18 @@ nisb_bayes <- function(admin_statistics_selected,
                          cor_XY_selected = cor_XY_selected_draws);
   
   if(length(unique(phi_draws)) > 5) {
+    #Crude rule-of-thumb to ensure that we do not massively overfit the data:
+    #Three observations are spent for estimating the variance function
+    #One is spent on the intercept
+    #Of the remaining observations, we can spend at most all but one on the polynomial function 
     #SMUB ~ phi model
+    smub_formula = as.formula(paste0("smub~",paste0(paste0("I(phi_centered^", 1:min(poly_degree, length(unique(phi_draws)) - 5),")"),collapse="+")));
     #The error variance is modeled as an increasing function of phi: sigma^2 * (lambda + |phi|^delta)^2
-    smub_vs_phi_mod = try(gls(smub ~ phi_centered + I(phi_centered^2) + I(phi_centered^3), data = all_draws, weights = varConstPower(form = ~phi)), silent = T);
+    smub_vs_phi_mod = try(gls(smub_formula, data = all_draws, weights = varConstPower(form = ~phi)), silent = T);
     if(class(smub_vs_phi_mod)=="try-error") {
-      smub_vs_phi_mod = try(lm(smub ~ phi_centered + I(phi_centered^2) + I(phi_centered^3), data = all_draws));
+      smub_vs_phi_mod = try(lm(smub_formula, data = all_draws));
+    } else {
+      smub_vs_phi_mod$call$model = smub_formula;
     }
     if(class(smub_vs_phi_mod) != "try-error") {
       phi_seq = c(intervals_at, seq(min(phi_draws), max(phi_draws), length = min(length(unique(phi_draws)),101)));
@@ -163,23 +191,36 @@ nisb_bayes <- function(admin_statistics_selected,
                                                  lwr = predict_smub_vs_phi_mod[,"fit"] + qnorm((1-conf_level)/2) * se_prediction,
                                                  predict_smub_vs_phi_mod, 
                                                  upr = predict_smub_vs_phi_mod[,"fit"] + qnorm((1+conf_level)/2) * se_prediction));
-      
       predict_smub_vs_phi_mod_to_print = predict_smub_vs_phi_mod[1:length(intervals_at),];
       colnames(predict_smub_vs_phi_mod_to_print) = c("phi",paste0(100*(1-conf_level)/2,"%"),"50%",paste0(100*(1+conf_level)/2,"%"));
     } else {
       predict_smub_vs_phi_mod_to_print = smub_vs_phi_mod;
     }
+  } else {
+    cat("SMUB message: ignoring values of 'intervals_at' and printing observed (not model-based) quantiles at each unique value of phi\n\n");
+    #SMUB
+    predict_smub_vs_phi_mod_to_print = tapply(all_draws[,"smub"], all_draws[,"phi"], quantile, p = c((1-conf_level)/2, 0.5, (1+conf_level)/2));
+    first_column = as.numeric(names(predict_smub_vs_phi_mod_to_print));
+    predict_smub_vs_phi_mod_to_print = cbind(first_column,matrix(unlist(tapply(all_draws[,"smub"], all_draws[,"phi"], quantile, p = c((1-conf_level)/2, 0.5, (1+conf_level)/2))),ncol = 3, byrow =T));
+    colnames(predict_smub_vs_phi_mod_to_print) = c("phi",paste0(100*(1-conf_level)/2,"%"),"50%",paste0(100*(1+conf_level)/2,"%"));
+  } 
+  
+  non_zero_phi_index = which(phi_draws > .Machine$double.eps^0.5);
+  if(length(unique(phi_draws[non_zero_phi_index])) > 5) {
     #SMAB ~ phi model
-    #The error variance is modeled as an increasing function of phi: sigma^2 * (lambda + |phi|^delta)^2
-    smab_vs_phi_mod = try(gls(smab ~ phi_centered + I(phi_centered^2) + I(phi_centered^3), data = all_draws, weights = varConstPower(form = ~phi)), silent = T);
+    smab_formula = as.formula(paste0("smab~",paste0(paste0("I(phi_centered^", 1:min(poly_degree, length(unique(phi_draws[non_zero_phi_index])) - 5),")"),collapse="+")));
+    #The error variance is modeled as an increasing function of phi: sigma^2 * (epsilon + |phi|^delta)^2, where epsilon ~= 0
+    smab_vs_phi_mod = try(gls(smab_formula, data = all_draws[non_zero_phi_index,], weights = varConstPower(form = ~ phi, fixed = list(const = .Machine$double.eps^0.5))), silent = T);
     if(class(smab_vs_phi_mod)=="try-error") {
-      smab_vs_phi_mod = try(lm(smab ~ phi_centered + I(phi_centered^2) + I(phi_centered^3), data = all_draws));
+      smab_vs_phi_mod = try(lm(smab_formula, data = all_draws[non_zero_phi_index,]));
+    } else {
+      smab_vs_phi_mod$call$model = smab_formula;
     }
     if(class(smab_vs_phi_mod) != "try-error") {
       phi_seq = c(intervals_at, seq(min(phi_draws), max(phi_draws), length = min(length(unique(phi_draws)),101)));
       predict_smab_vs_phi_mod = cbind(fit = predict(smab_vs_phi_mod, newdata = data.frame(phi_centered = phi_seq - mean(all_draws$phi))));
       if(class(smab_vs_phi_mod)=="gls") {
-        variance_components = c(exp(attributes(smab_vs_phi_mod$apVar)$Pars["varStruct.const"]),
+        variance_components = c(varStruct.const = .Machine$double.eps^0.5,
                                 attributes(smab_vs_phi_mod$apVar)$Pars["varStruct.power"], 
                                 exp(attributes(smab_vs_phi_mod$apVar)$Pars["lSigma"]));
         se_prediction = variance_components["lSigma"]*(variance_components["varStruct.const"] + phi_seq^variance_components["varStruct.power"]);
@@ -197,12 +238,7 @@ nisb_bayes <- function(admin_statistics_selected,
       predict_smab_vs_phi_mod_to_print = smab_vs_phi_mod;
     }
   } else {
-    cat("ignoring values of 'intervals_at' and printing observed (not model-based) quantiles at each unique value of phi");
-    #SMUB
-    predict_smub_vs_phi_mod_to_print = tapply(all_draws[,"smub"], all_draws[,"phi"], quantile, p = c((1-conf_level)/2, 0.5, (1+conf_level)/2));
-    first_column = as.numeric(names(predict_smub_vs_phi_mod_to_print));
-    predict_smub_vs_phi_mod_to_print = cbind(first_column,matrix(unlist(tapply(all_draws[,"smub"], all_draws[,"phi"], quantile, p = c((1-conf_level)/2, 0.5, (1+conf_level)/2))),ncol = 3, byrow =T));
-    colnames(predict_smub_vs_phi_mod_to_print) = c("phi",paste0(100*(1-conf_level)/2,"%"),"50%",paste0(100*(1+conf_level)/2,"%"));
+    cat("SMAB message: ignoring values of 'intervals_at' and printing observed (not model-based) quantiles at each unique value of phi\n\n");
     #SMAB
     predict_smab_vs_phi_mod_to_print = tapply(all_draws[,"smab"], all_draws[,"phi"], quantile, p = c((1-conf_level)/2, 0.5, (1+conf_level)/2));
     first_column = as.numeric(names(predict_smab_vs_phi_mod_to_print));
@@ -217,23 +253,23 @@ nisb_bayes <- function(admin_statistics_selected,
   
   if(return_plot %in% c("SMAB","SMUB","smab","smub")) {
     return_plot = tolower(return_plot);
-    if(length(unique(phi_draws)) > 5) {
-      if(exists(paste0("predict_",return_plot,"_vs_phi_mod"))) {
-        ribbon_data = get(paste0("predict_",return_plot,"_vs_phi_mod"))[-(1:length(intervals_at)),]
-        phi_plot = ggplot() + 
-          geom_point(data = all_draws, aes_string(x = "phi", y = return_plot), size = 0.4, col = "#33333370") +
-          geom_ribbon(data = ribbon_data, aes(x = phi, ymin = lwr, ymax = upr), fill = "#ff000050") +
-          geom_path(data = ribbon_data, aes(x = phi, y = fit), size = 1., col = "#ff0000") +
-          theme(legend.position = "top") + 
-          labs(x=expression(phi),
-               y=toupper(return_plot)) +
-          theme(text = element_text(size = 18));
-      } else {
-        warning("No suitable regression model was found, so no plot returned")
-      }
-    } else {
+    if(exists(paste0("predict_",return_plot,"_vs_phi_mod"))) {
+      ribbon_data = get(paste0("predict_",return_plot,"_vs_phi_mod"))[-(1:length(intervals_at)),]
+      phi_plot = ggplot() + 
+        geom_point(data = all_draws, aes_string(x = "phi", y = return_plot), size = 0.4, col = "#33333370") +
+        geom_ribbon(data = ribbon_data, aes(x = phi, ymin = lwr, ymax = upr), fill = "#ff000050") +
+        geom_path(data = ribbon_data, aes(x = phi, y = fit), size = 1., col = "#ff0000") +
+        theme(legend.position = "top") + 
+        labs(x=expression(phi),
+             y=toupper(return_plot)) +
+        theme(text = element_text(size = 18));
+      #Don't overwhelm the plot device if there are lots of unique draws. 
+    } else if(length(unique(phi_draws)) < 10) {
       phi_plot = ggplot(data = all_draws) + 
-        geom_boxplot(aes_string(x = "factor(phi)", y = return_plot, group = "factor(phi)"), size = 0.5, col = "#33333380") +
+        geom_boxplot(aes_string(x = "factor(phi, labels = formatC(sort(unique(phi)), format = 'f', digits = 3))", 
+                                y = return_plot), 
+                     size = 0.5, 
+                     col = "#33333380") +
         theme(legend.position = "top") + 
         labs(x = expression(phi),
              y = toupper(return_plot)) +
@@ -249,12 +285,12 @@ nisb_bayes <- function(admin_statistics_selected,
               mean_X_pop = mean_X_pop,
               random_seed = random_seed, 
               all_draws = all_draws,
-              smub_summaries_marginal = quantile(all_draws[,"smub"],p = c((1 - conf_level) / 2, 0.5, (1 + conf_level) / 2)),
-              smab_summaries_marginal = quantile(all_draws[,"smab"],p = c((1 - conf_level) / 2, 0.5, (1 + conf_level) / 2)),
-              smub_summaries_conditional = predict_smub_vs_phi_mod_to_print,
-              smab_summaries_conditional = predict_smab_vs_phi_mod_to_print,
-              smub_point_est = smub_point_est,
-              smab_point_est = smab_point_est))
+              smub_summaries_marginal = round(quantile(all_draws[,"smub"],p = c((1 - conf_level) / 2, 0.5, (1 + conf_level) / 2)),sig_digits_return),
+              smab_summaries_marginal = round(quantile(all_draws[,"smab"],p = c((1 - conf_level) / 2, 0.5, (1 + conf_level) / 2)),sig_digits_return),
+              smub_summaries_conditional = round(predict_smub_vs_phi_mod_to_print,sig_digits_return),
+              smab_summaries_conditional = round(predict_smab_vs_phi_mod_to_print,sig_digits_return),
+              smub_point_est = round(smub_point_est,sig_digits_return),
+              smab_point_est = round(smab_point_est),sig_digits_return))
   
 }
 

--- a/nisb_functions.R
+++ b/nisb_functions.R
@@ -127,7 +127,7 @@ nisb_bayes <- function(admin_statistics_selected,
   
   #Draw phi using provided string
   phi_draws = eval(parse(text=phi_character));
-  phi_draws = pmax(.Machine$double.eps, pmin(1 - .Machine$double.eps, phi_draws));
+  phi_draws = pmax(.Machine$double.eps, phi_draws);
   
   #Joint draws from distribution corresponding to non-selected population
   #Note: This next line makes a slight abuse of notation by overriding an existing variable with a new value. This is intentional


### PR DESCRIPTION
1. added poly_degree and sig_digits_return to nisb_bayes function
2. added resampling step to ensure that the implied correlation of x and y between the sampled units is always positive
3. weird singularities aris when phi is exactly zero and fed into the model. I replace all values of phi=0 and phi=1 with phi = epsilon and phi = 1-epsilon, respectively, which addresses this issue.

The third edit may need some more explanation, as it wasn't one I was planning on making. I had noticed in previous testing of the code that when I provide a dense set of prespecified phis, i.e. 

`phi_character = "rep(seq(0, 1, length = 101), length=ndraws)"`

the gls model wouldn't fit because the error variance function, which we are modeling as sigma^2 * (lambda + |phi|^delta)^2, encountered some weird singularity. However, the gls function has no problems when we use `phi_character = "runif(ndraws)', even though this is basically an equivalent set of phis. I saw this message again today when testing my edits and became frustrated at it. It turns out that providing phi exactly equal to 0 causes the problem. My fix is to replace all instances of phi = 0 with phi = .Machine$double.eps, which is about 10^-16 on my computer. This is enough to fix the singularity issue. Let me know what you think about this. 
